### PR TITLE
takes out negative margin top on footer

### DIFF
--- a/assets/css/codesquad_css.css
+++ b/assets/css/codesquad_css.css
@@ -1445,9 +1445,9 @@ select {
 	padding: 10px 0 0 0;
 }
 
-footer {
+/* footer {
 	margin-top: -10px;
-}
+} */
   
 /* The actual timeline (the vertical ruler) */
 .timeline::after {


### PR DESCRIPTION
For some reason, taking out this line of code fixes the volunteers page and does not appear to affect the rest of the footers.